### PR TITLE
Fix test script to transpile TypeScript

### DIFF
--- a/test-patterns.js
+++ b/test-patterns.js
@@ -1,5 +1,19 @@
 // Quick test of the new pattern structure
-const { patterns, getPatternsBySourceType, getUserContributedPatterns, getHighRatedPatterns } = require('./src/data/patterns.ts');
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patterns-'));
+execSync(`tsc src/data/patterns.ts --target ES2017 --module commonjs --outDir ${tmpDir}`);
+const outFile = path.join(tmpDir, 'data', 'patterns.js');
+
+const {
+  patterns,
+  getPatternsBySourceType,
+  getUserContributedPatterns,
+  getHighRatedPatterns
+} = require(outFile);
 
 console.log('🧪 Testing Pattern Structure');
 console.log('============================');


### PR DESCRIPTION
## Summary
- run `tsc` dynamically inside the test script so that Node can execute the TypeScript data file

## Testing
- `node test-patterns.js`

------
https://chatgpt.com/codex/tasks/task_e_685cf641dfac8324857d43f738224a35