### PR TITLE
Fix duplicate key warnings

### DIFF
--- a/src/screens/MatchesScreen.tsx
+++ b/src/screens/MatchesScreen.tsx
@@ -245,8 +245,8 @@ export default function MatchesScreen({ navigation }: MatchesScreenProps) {
         </Text>
         
         <View style={styles.matchPatterns}>
-          {(item.knownPatterns || []).slice(0, 3).map((pattern: string, index: number) => (
-            <View key={index} style={styles.patternTag}>
+          {(item.knownPatterns || []).slice(0, 3).map((pattern: string) => (
+            <View key={pattern} style={styles.patternTag}>
               <Text style={styles.patternText}>{pattern}</Text>
             </View>
           ))}
@@ -301,8 +301,8 @@ export default function MatchesScreen({ navigation }: MatchesScreenProps) {
         </Text>
         
         <View style={styles.searchResultPatterns}>
-          {(item.knownPatterns || []).slice(0, 2).map((pattern: string, index: number) => (
-            <View key={index} style={styles.patternTagSmall}>
+          {(item.knownPatterns || []).slice(0, 2).map((pattern: string) => (
+            <View key={pattern} style={styles.patternTagSmall}>
               <Text style={styles.patternTextSmall}>{pattern}</Text>
             </View>
           ))}

--- a/src/screens/MatchesScreen_NEW.tsx
+++ b/src/screens/MatchesScreen_NEW.tsx
@@ -208,8 +208,8 @@ export default function MatchesScreen({}: MatchesScreenProps) {
           <View style={styles.patternGroup}>
             <Text style={styles.patternGroupTitle}>Known Patterns ({item.knownPatterns.length})</Text>
             <View style={styles.patternList}>
-              {item.knownPatterns.slice(0, 3).map((pattern: string, index: number) => (
-                <View key={index} style={styles.patternTag}>
+              {item.knownPatterns.slice(0, 3).map((pattern: string) => (
+                <View key={pattern} style={styles.patternTag}>
                   <Text style={styles.patternTagText}>{pattern}</Text>
                 </View>
               ))}
@@ -482,8 +482,8 @@ export default function MatchesScreen({}: MatchesScreenProps) {
         <View style={styles.patternGroup}>
           <Text style={styles.patternGroupTitle}>Shared Patterns ({item.sharedPatterns.length})</Text>
           <View style={styles.patternList}>
-            {item.sharedPatterns.slice(0, 2).map((pattern, index) => (
-              <View key={index} style={styles.patternTag}>
+            {item.sharedPatterns.slice(0, 2).map((pattern) => (
+              <View key={pattern} style={styles.patternTag}>
                 <Text style={styles.patternTagText}>{pattern}</Text>
               </View>
             ))}
@@ -497,8 +497,8 @@ export default function MatchesScreen({}: MatchesScreenProps) {
           <View style={styles.patternGroup}>
             <Text style={styles.patternGroupTitle}>They Can Teach You</Text>
             <View style={styles.patternList}>
-              {item.canTeach.slice(0, 2).map((pattern, index) => (
-                <View key={index} style={[styles.patternTag, styles.teachTag]}>
+              {item.canTeach.slice(0, 2).map((pattern) => (
+                <View key={pattern} style={[styles.patternTag, styles.teachTag]}>
                   <Text style={styles.teachTagText}>{pattern}</Text>
                 </View>
               ))}
@@ -510,8 +510,8 @@ export default function MatchesScreen({}: MatchesScreenProps) {
           <View style={styles.patternGroup}>
             <Text style={styles.patternGroupTitle}>You Can Teach Them</Text>
             <View style={styles.patternList}>
-              {item.canLearn.slice(0, 2).map((pattern, index) => (
-                <View key={index} style={[styles.patternTag, styles.learnTag]}>
+              {item.canLearn.slice(0, 2).map((pattern) => (
+                <View key={pattern} style={[styles.patternTag, styles.learnTag]}>
                   <Text style={styles.learnTagText}>{pattern}</Text>
                 </View>
               ))}

--- a/src/screens/PatternsScreen.tsx
+++ b/src/screens/PatternsScreen.tsx
@@ -178,8 +178,8 @@ export default function PatternsScreen() {
         </View>
 
         <View style={styles.patternTags}>
-          {item.tags.slice(0, 3).map((tag, index) => (
-            <View key={index} style={styles.tag}>
+          {item.tags.slice(0, 3).map((tag) => (
+            <View key={tag} style={styles.tag}>
               <Text style={styles.tagText}>{tag}</Text>
             </View>
           ))}

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -58,8 +58,8 @@ export default function ProfileScreen() {
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Preferred Props</Text>
           <View style={styles.propsList}>
-            {userProfile?.preferredProps.map((prop, index) => (
-              <View key={index} style={styles.propTag}>
+            {userProfile?.preferredProps.map((prop) => (
+              <View key={prop} style={styles.propTag}>
                 <Text style={styles.propText}>
                   {prop.charAt(0).toUpperCase() + prop.slice(1)}
                 </Text>
@@ -90,8 +90,11 @@ export default function ProfileScreen() {
           <Text style={styles.sectionTitle}>Availability</Text>
           {userProfile?.availability && userProfile.availability.length > 0 ? (
             <View style={styles.availabilityList}>
-              {userProfile.availability.map((slot, index) => (
-                <View key={index} style={styles.availabilityItem}>
+              {userProfile.availability.map((slot) => (
+                <View
+                  key={`${slot.day}-${slot.startTime}-${slot.endTime}`}
+                  style={styles.availabilityItem}
+                >
                   <Text style={styles.dayText}>
                     {slot.day.charAt(0).toUpperCase() + slot.day.slice(1)}
                   </Text>

--- a/src/screens/UserProfileViewScreen.tsx
+++ b/src/screens/UserProfileViewScreen.tsx
@@ -136,8 +136,8 @@ export default function UserProfileViewScreen({ route, navigation }: UserProfile
             Patterns you both know that you could practice together
           </Text>
           <View style={styles.patternGrid}>
-            {sharedPatterns.map((pattern, index) => (
-              <View key={index} style={styles.patternCard}>
+            {sharedPatterns.map((pattern) => (
+              <View key={pattern} style={styles.patternCard}>
                 <Text style={styles.patternName}>{pattern}</Text>
               </View>
             ))}
@@ -152,8 +152,8 @@ export default function UserProfileViewScreen({ route, navigation }: UserProfile
               Patterns they know that you want to learn
             </Text>
             <View style={styles.patternGrid}>
-              {canTeach.map((pattern, index) => (
-                <View key={index} style={[styles.patternCard, styles.teachCard]}>
+              {canTeach.map((pattern) => (
+                <View key={pattern} style={[styles.patternCard, styles.teachCard]}>
                   <Text style={[styles.patternName, styles.teachText]}>{pattern}</Text>
                 </View>
               ))}
@@ -169,8 +169,8 @@ export default function UserProfileViewScreen({ route, navigation }: UserProfile
               Patterns you know that they want to learn
             </Text>
             <View style={styles.patternGrid}>
-              {canLearn.map((pattern, index) => (
-                <View key={index} style={[styles.patternCard, styles.learnCard]}>
+              {canLearn.map((pattern) => (
+                <View key={pattern} style={[styles.patternCard, styles.learnCard]}>
                   <Text style={[styles.patternName, styles.learnText]}>{pattern}</Text>
                 </View>
               ))}


### PR DESCRIPTION
## Summary
- use prop string as key in ProfileScreen
- ensure availability slot keys are unique
- use tag string as key for patterns
- fix key warnings in matches screens
- use pattern string as key in UserProfileViewScreen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cfefb161c83249aa5e18794a54d26