### PR TITLE
Refocus app on pattern discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # PatternPals 🤹‍♂️
 
-A cross-platform mobile app built with React Native and Expo that helps jugglers find compatible partners for passing patterns.
+A cross-platform mobile app built with React Native and Expo that serves as a centralized pattern library with smart juggling recommendations.
 
 ## 🎯 Features
 
-### ✅ **Fully Implemented & Working**
+-### ✅ **Fully Implemented & Working**
 
+- **Pattern Recommendations**: Get quick suggestions based on your skills
 - **Smart Matching**: Find partners based on skill level, availability, and pattern preferences
 - **Pattern Library**: Browse and track 20+ passing patterns with difficulty levels and user contributions  
 - **Pattern Management**: Mark patterns as known, want to learn, or want to avoid with persistent storage
@@ -220,5 +221,5 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ---
 
-**Ready to find your juggling partner? Let's get passing! 🤹‍♀️**
-Bringing jugglers together through smart pairing, scheduling, and pattern recommendations.
+**Ready to discover your next juggling pattern? Let's get juggling! 🤹‍♀️**
+Sharing the world's juggling knowledge with quick suggestions and a growing pattern library.

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -6,11 +6,13 @@ import {
   SafeAreaView,
   ScrollView,
   TouchableOpacity,
+  Alert,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useAuth } from '../hooks/useAuth';
 import { useUserPatterns } from '../hooks/useUserPatterns';
 import { patterns } from '../data/patterns';
+import { PatternIntelligenceService } from '../services';
 
 export default function HomeScreen() {
   const navigation = useNavigation<any>();
@@ -32,6 +34,30 @@ export default function HomeScreen() {
     if (hour < 12) return 'Good morning';
     if (hour < 18) return 'Good afternoon';
     return 'Good evening';
+  };
+
+  const handleSuggestPattern = () => {
+    if (!userProfile) return;
+    const [recommendation] = PatternIntelligenceService.getSmartRecommendations(
+      userProfile,
+      1
+    );
+
+    if (recommendation) {
+      Alert.alert(
+        'Suggested Pattern',
+        `${recommendation.name}\n\n${recommendation.description}`,
+        [
+          {
+            text: 'View Details',
+            onPress: () => navigation.navigate('Patterns'),
+          },
+          { text: 'Close', style: 'cancel' },
+        ]
+      );
+    } else {
+      Alert.alert('No suggestion', 'Keep practicing your favorites!');
+    }
   };
 
   const recentActivity = [
@@ -69,25 +95,25 @@ export default function HomeScreen() {
             {getTimeOfDayGreeting()}, {userProfile.name}! 🤹‍♂️
           </Text>
           <Text style={styles.subText}>
-            Ready to find your next juggling partner?
+            Looking for a new pattern to try?
           </Text>
         </View>
 
         <View style={styles.quickActions}>
           <Text style={styles.sectionTitle}>Quick Actions</Text>
           
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.actionCard}
-            onPress={() => navigation.navigate('Matches')}
+            onPress={handleSuggestPattern}
           >
-            <Text style={styles.actionIcon}>🔍</Text>
+            <Text style={styles.actionIcon}>🎲</Text>
             <View style={styles.actionContent}>
-              <Text style={styles.actionTitle}>Find Matches</Text>
-              <Text style={styles.actionSubtitle}>Discover compatible jugglers nearby</Text>
+              <Text style={styles.actionTitle}>Suggest Pattern</Text>
+              <Text style={styles.actionSubtitle}>Get a quick recommendation</Text>
             </View>
           </TouchableOpacity>
 
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.actionCard}
             onPress={() => navigation.navigate('Patterns')}
           >
@@ -95,6 +121,17 @@ export default function HomeScreen() {
             <View style={styles.actionContent}>
               <Text style={styles.actionTitle}>Browse Patterns</Text>
               <Text style={styles.actionSubtitle}>Explore {patterns.length} passing patterns</Text>
+            </View>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.actionCard}
+            onPress={() => navigation.navigate('Matches')}
+          >
+            <Text style={styles.actionIcon}>🔍</Text>
+            <View style={styles.actionContent}>
+              <Text style={styles.actionTitle}>Find Matches</Text>
+              <Text style={styles.actionSubtitle}>Discover compatible jugglers nearby</Text>
             </View>
           </TouchableOpacity>
 

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -27,14 +27,14 @@ export default function OnboardingScreen({ navigation }: Props) {
           <Text style={styles.logoText}>🤹‍♂️</Text>
           <Text style={styles.title}>PatternPals</Text>
           <Text style={styles.subtitle}>
-            Find your perfect juggling partner
+            Discover your next juggling pattern
           </Text>
         </View>
 
         <View style={styles.featuresContainer}>
           <View style={styles.feature}>
-            <Text style={styles.featureIcon}>👥</Text>
-            <Text style={styles.featureText}>Match with compatible jugglers</Text>
+            <Text style={styles.featureIcon}>🎲</Text>
+            <Text style={styles.featureText}>Quick pattern suggestions</Text>
           </View>
           <View style={styles.feature}>
             <Text style={styles.featureIcon}>📚</Text>


### PR DESCRIPTION
## Summary
- highlight pattern recommendations in README
- add pattern suggestion quick action on Home Screen
- tweak onboarding copy to emphasize pattern discovery

## Testing
- `node test-pattern-library.js` *(fails: Missing initializer in const declaration)*
- `node final-status-check.js` *(fails: Cannot find module '@supabase/supabase-js')*


------
https://chatgpt.com/codex/tasks/task_e_688001a67ba0832486bff22110047bb1