### PR TITLE
Simplify matching features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # PatternPals 🤹‍♂️
 
-A cross-platform mobile app built with React Native and Expo that helps jugglers find compatible partners for passing patterns.
+A cross-platform mobile app built with React Native and Expo that serves as a centralized pattern library with smart juggling recommendations.
 
 ## 🎯 Features
 
-### ✅ **Fully Implemented & Working**
+-### ✅ **Fully Implemented & Working**
 
-- **Smart Matching**: Find partners based on skill level, availability, and pattern preferences
+- **Pattern Recommendations**: Get quick suggestions based on your skills
 - **Pattern Library**: Browse and track 20+ passing patterns with difficulty levels and user contributions  
 - **Pattern Management**: Mark patterns as known, want to learn, or want to avoid with persistent storage
 - **User Authentication**: Complete sign-up/sign-in flow with profile creation
 - **Profile Management**: Detailed user profiles with experience levels, preferences, and statistics
 - **Availability Management**: Set weekly availability with time slots
-- **Session Scheduling**: Schedule practice sessions with partners including location and notes
 - **Real-Time Chat**: In-app messaging system between connected users with live updates
-- **Notifications System**: Real-time notifications for matches, sessions, and announcements
+- **Notifications System**: Real-time notifications for pattern updates and announcements
 - **Settings & Preferences**: Comprehensive settings with notification controls and privacy options
 - **Help & Support**: Built-in help system with FAQ and support contacts
 - **Navigation**: Seamless navigation between all app features
@@ -57,7 +56,7 @@ A cross-platform mobile app built with React Native and Expo that helps jugglers
 
 ### **What Works Out of the Box:**
 
-- ✅ **Complete User Flow**: Sign up → Create Profile → Browse Patterns → Find Matches → Schedule Sessions
+- ✅ **Complete User Flow**: Sign up → Create Profile → Browse Patterns → Track Progress
 - ✅ **Data Persistence**: All your progress and preferences are saved
 - ✅ **Full Navigation**: Every screen and feature is connected and working
 - ✅ **Mock Backend**: Realistic data simulation for testing all features
@@ -71,11 +70,6 @@ A cross-platform mobile app built with React Native and Expo that helps jugglers
 - User progress statistics (patterns known, learning, availability)
 - Recent activity feed
 
-### **👥 Matches Screen**
-- Browse compatible juggling partners
-- Match compatibility scores based on shared patterns
-- Filter between "Discover" and "Connection Requests" tabs
-- Connect with other jugglers
 
 ### **📚 Patterns Screen**
 - Complete library of passing patterns with descriptions
@@ -84,7 +78,7 @@ A cross-platform mobile app built with React Native and Expo that helps jugglers
 - Pattern details including required jugglers and props
 
 ### **🔔 Notifications Screen**
-- Real-time notifications for matches, sessions, and events
+- Real-time notifications for pattern updates and events
 - Filter notifications by type (All/Unread)
 - Mark individual or all notifications as read
 - Pull-to-refresh functionality
@@ -97,7 +91,6 @@ A cross-platform mobile app built with React Native and Expo that helps jugglers
 ### **⚙️ Additional Screens**
 - **Profile Edit**: Update personal information and preferences
 - **Availability Management**: Set weekly time slots for juggling
-- **Session Scheduling**: Plan practice sessions with partners
 - **Settings**: Notification preferences and app configuration
 - **Help & Support**: FAQ, contact support, and resources
 
@@ -153,9 +146,8 @@ All features are now powered by a real-time Supabase backend:
 2. **Complete Profile**: Set your experience level and preferences  
 3. **Browse Patterns**: Search and mark patterns as known/learning
 4. **Check Notifications**: See mock notifications and mark as read
-5. **Schedule Sessions**: Plan practice sessions with date/time/location
-6. **Manage Availability**: Set your weekly juggling schedule
-7. **Explore Settings**: Configure notifications and preferences
+5. **Manage Availability**: Set your weekly juggling schedule
+6. **Explore Settings**: Configure notifications and preferences
 
 ## 📋 Roadmap
 
@@ -165,9 +157,7 @@ All features are now powered by a real-time Supabase backend:
 - [x] Pattern library with search/filter functionality
 - [x] User pattern management (known/want to learn/avoid)
 - [x] Persistent data storage with AsyncStorage
-- [x] Mock matching system with compatibility scores
 - [x] Notifications system with real-time updates
-- [x] Session scheduling with date/time/location
 - [x] Availability management with weekly time slots
 - [x] Settings and preferences management
 - [x] Help and support system
@@ -220,5 +210,5 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ---
 
-**Ready to find your juggling partner? Let's get passing! 🤹‍♀️**
-Bringing jugglers together through smart pairing, scheduling, and pattern recommendations.
+**Ready to discover your next juggling pattern? Let's get juggling! 🤹‍♀️**
+Sharing the world's juggling knowledge with quick suggestions and a growing pattern library.

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -14,7 +14,6 @@ import HomeScreen from '../screens/HomeScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import ProfileEditScreen from '../screens/ProfileEditScreen';
 import AvailabilityManagementScreen from '../screens/AvailabilityManagementScreen';
-import MatchesScreen from '../screens/MatchesScreen';
 import PatternsScreen from '../screens/PatternsScreen';
 import NotificationsScreen from '../screens/NotificationsScreen';
 import SessionSchedulingScreen from '../screens/SessionSchedulingScreen';
@@ -64,7 +63,6 @@ export type RootStackParamList = {
 
 export type MainTabParamList = {
   Home: undefined;
-  Matches: undefined;
   Patterns: undefined;
   Chat: undefined;
   Profile: undefined;
@@ -85,9 +83,6 @@ function MainTabs() {
           switch (route.name) {
             case 'Home':
               iconName = focused ? 'home' : 'home-outline';
-              break;
-            case 'Matches':
-              iconName = focused ? 'people' : 'people-outline';
               break;
             case 'Patterns':
               iconName = focused ? 'library' : 'library-outline';
@@ -148,11 +143,6 @@ function MainTabs() {
         name="Home" 
         component={HomeScreen} 
         options={{ title: 'PatternPals' }}
-      />
-      <MainTab.Screen 
-        name="Matches" 
-        component={MatchesScreen} 
-        options={{ title: 'Matches' }}
       />
       <MainTab.Screen 
         name="Patterns" 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -6,11 +6,13 @@ import {
   SafeAreaView,
   ScrollView,
   TouchableOpacity,
+  Alert,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useAuth } from '../hooks/useAuth';
 import { useUserPatterns } from '../hooks/useUserPatterns';
 import { patterns } from '../data/patterns';
+import { PatternIntelligenceService } from '../services';
 
 export default function HomeScreen() {
   const navigation = useNavigation<any>();
@@ -34,6 +36,30 @@ export default function HomeScreen() {
     return 'Good evening';
   };
 
+  const handleSuggestPattern = () => {
+    if (!userProfile) return;
+    const [recommendation] = PatternIntelligenceService.getSmartRecommendations(
+      userProfile,
+      1
+    );
+
+    if (recommendation) {
+      Alert.alert(
+        'Suggested Pattern',
+        `${recommendation.name}\n\n${recommendation.description}`,
+        [
+          {
+            text: 'View Details',
+            onPress: () => navigation.navigate('Patterns'),
+          },
+          { text: 'Close', style: 'cancel' },
+        ]
+      );
+    } else {
+      Alert.alert('No suggestion', 'Keep practicing your favorites!');
+    }
+  };
+
   const recentActivity = [
     {
       id: '1',
@@ -45,16 +71,8 @@ export default function HomeScreen() {
     },
     {
       id: '2',
-      type: 'match_found',
-      title: 'New match found',
-      subtitle: 'Sarah Johnson - 87% compatibility',
-      time: '1 day ago',
-      icon: '👥',
-    },
-    {
-      id: '3',
-      type: 'session_completed',
-      title: 'Practice session completed',
+      type: 'pattern_practiced',
+      title: 'Great practice session',
       subtitle: 'With Alex Chen - 90 minutes',
       time: '3 days ago',
       icon: '🎯',
@@ -69,25 +87,25 @@ export default function HomeScreen() {
             {getTimeOfDayGreeting()}, {userProfile.name}! 🤹‍♂️
           </Text>
           <Text style={styles.subText}>
-            Ready to find your next juggling partner?
+            Looking for a new pattern to try?
           </Text>
         </View>
 
         <View style={styles.quickActions}>
           <Text style={styles.sectionTitle}>Quick Actions</Text>
           
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.actionCard}
-            onPress={() => navigation.navigate('Matches')}
+            onPress={handleSuggestPattern}
           >
-            <Text style={styles.actionIcon}>🔍</Text>
+            <Text style={styles.actionIcon}>🎲</Text>
             <View style={styles.actionContent}>
-              <Text style={styles.actionTitle}>Find Matches</Text>
-              <Text style={styles.actionSubtitle}>Discover compatible jugglers nearby</Text>
+              <Text style={styles.actionTitle}>Suggest Pattern</Text>
+              <Text style={styles.actionSubtitle}>Get a quick recommendation</Text>
             </View>
           </TouchableOpacity>
 
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.actionCard}
             onPress={() => navigation.navigate('Patterns')}
           >
@@ -98,18 +116,7 @@ export default function HomeScreen() {
             </View>
           </TouchableOpacity>
 
-          <TouchableOpacity 
-            style={styles.actionCard}
-            onPress={() => navigation.navigate('SessionScheduling')}
-          >
-            <Text style={styles.actionIcon}>📅</Text>
-            <View style={styles.actionContent}>
-              <Text style={styles.actionTitle}>Schedule Session</Text>
-              <Text style={styles.actionSubtitle}>Plan your next practice</Text>
-            </View>
-          </TouchableOpacity>
-
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.actionCard}
             onPress={() => navigation.navigate('Profile')}
           >

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -27,22 +27,22 @@ export default function OnboardingScreen({ navigation }: Props) {
           <Text style={styles.logoText}>🤹‍♂️</Text>
           <Text style={styles.title}>PatternPals</Text>
           <Text style={styles.subtitle}>
-            Find your perfect juggling partner
+            Discover your next juggling pattern
           </Text>
         </View>
 
         <View style={styles.featuresContainer}>
           <View style={styles.feature}>
-            <Text style={styles.featureIcon}>👥</Text>
-            <Text style={styles.featureText}>Match with compatible jugglers</Text>
+            <Text style={styles.featureIcon}>🎲</Text>
+            <Text style={styles.featureText}>Quick pattern suggestions</Text>
           </View>
           <View style={styles.feature}>
             <Text style={styles.featureIcon}>📚</Text>
             <Text style={styles.featureText}>Learn new passing patterns</Text>
           </View>
           <View style={styles.feature}>
-            <Text style={styles.featureIcon}>🕐</Text>
-            <Text style={styles.featureText}>Schedule practice sessions</Text>
+            <Text style={styles.featureIcon}>⭐</Text>
+            <Text style={styles.featureText}>Save favorite patterns</Text>
           </View>
           <View style={styles.feature}>
             <Text style={styles.featureIcon}>🔔</Text>


### PR DESCRIPTION
## Summary
- remove Matches tab from navigation
- clean up HomeScreen quick actions
- tweak onboarding list
- update README for new focus

## Testing
- `node test-pattern-library.js` *(fails: Missing initializer in const declaration)*
- `node final-status-check.js` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688001a67ba0832486bff22110047bb1